### PR TITLE
Add tighter tests on payload lengths

### DIFF
--- a/tester.py
+++ b/tester.py
@@ -319,6 +319,7 @@ class HTTPTester():
         assert res["status_code"] == 200, f"Status expected '200', returned '{res['status_code']}'"
         clength = res["headers"].get("content-length", "[ABSENT]")
         assert clength == "38457", f"Content-Length expected '38457', returned '{clength}'"
+        assert res["payload"] and res["payload_size"] == 38457, f"Payload length expected 38457 bytes, returned '{res["payload_size"]}'"
 
 
     @make_request("get-url.http", PATH="/a1-test/2/0.JPEG")
@@ -335,6 +336,7 @@ class HTTPTester():
         assert res["status_code"] == 200, f"Status expected '200', returned '{res['status_code']}'"
         clength = res["headers"].get("content-length", "[ABSENT]")
         assert clength == "0", f"Content-Length expected '0', returned '{clength}'"
+        assert not res["payload"], f"Payload length expected zero bytes, returned '{res["payload_size"]}'"
 
 
     @make_request("get-url.http", PATH="/a1-test/4/directory3isemptyt")
@@ -343,6 +345,7 @@ class HTTPTester():
         assert res["status_code"] == 200, f"Status expected '200', returned '{res['status_code']}'"
         clength = res["headers"].get("content-length", "[ABSENT]")
         assert clength == "0", f"Content-Length expected '0', returned '{clength}'"
+        assert not res["payload"], f"Payload length expected zero bytes, returned '{res["payload_size"]}'"
         ctype = res["headers"].get("content-type", "[ABSENT]")
         assert "/" in ctype, f"Content-Type should be of the form '.*/.*', returned '{ctype}'"
 


### PR DESCRIPTION
Do not rely only on the `Content-Length` header.