### PR TITLE
Update test_cgi_env_query_str to use dynamic USERAGENT

### DIFF
--- a/servertester/testsuites/cs531a5.py
+++ b/servertester/testsuites/cs531a5.py
@@ -287,7 +287,7 @@ class CS531A5(HTTPTester):
         self.check_mime_is(report, "text/html")
         self.check_header_is(report, "Transfer-Encoding", "chunked")
         self.check_header_absent(report, "ETag")
-        self.check_payload_contains(report, "QUERY_STRING = var1=foo&var2=bar", "HTTP_USER_AGENT = CS 531-F18 A5 automated Checker")
+        self.check_payload_contains(report, "QUERY_STRING = var1=foo&var2=bar", "HTTP_USER_AGENT = {}".format(self.USERAGENT))
 
 
     @HTTPTester.request("get-path.http", PATH="/a5-test/limited3/env.cgi?var1=foo&var2=bar")

--- a/servertester/testsuites/cs531a5.py
+++ b/servertester/testsuites/cs531a5.py
@@ -287,7 +287,7 @@ class CS531A5(HTTPTester):
         self.check_mime_is(report, "text/html")
         self.check_header_is(report, "Transfer-Encoding", "chunked")
         self.check_header_absent(report, "ETag")
-        self.check_payload_contains(report, "QUERY_STRING = var1=foo&var2=bar", "HTTP_USER_AGENT = {}".format(self.USERAGENT))
+        self.check_payload_contains(report, "QUERY_STRING = var1=foo&var2=bar", f"HTTP_USER_AGENT = {self.USERAGENT}")
 
 
     @HTTPTester.request("get-path.http", PATH="/a5-test/limited3/env.cgi?var1=foo&var2=bar")


### PR DESCRIPTION
It appears this test was missed in the past refactor to remove the constant useragent.
This makes the test use the user-agent that is generated for each run.