### PR TITLE
Show header separator only if present

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,8 @@ if __name__ == "__main__":
         if result["res"]["raw_headers"]:
             print("< " + result["res"]["raw_headers"].replace("\n", "\n< "))
         if result["res"]["payload"]:
-            print("< ")
+            if "Missing empty line after headers" not in result["errors"]:
+                print("< ")
             if print_text_payload and result["res"]["headers"].get("content-type", "text/plain").split('/')[0] in ["text", "message"]:
                 print(result["res"]["payload"].decode())
             else:

--- a/templates/index.html
+++ b/templates/index.html
@@ -434,7 +434,7 @@
           let pld = r.res.payload_size ? ['text', 'message'].includes(ctype.split('/')[0]) ? atob(r.res.payload).replace(/[&<>"']/g, m => htmlEscapes[m]) : `<object data="data:${ctype};base64,${r.res.payload}">[<a href="data:${ctype};base64,${r.res.payload}" target="_blank">Download ${ctype} payload</a>]</object>` : '';
           markup += `
           <h4>Original Response <span class="description">(Payload: ${r.res.payload_size} bytes, Connection: ${r.res.connection})</span></h4>
-          <pre><code>${r.res.raw_headers.replace(/[&<>"']/g, m => htmlEscapes[m])}\r\n\r\n${pld}</code></pre>`;
+          <pre><code>${r.res.raw_headers.replace(/[&<>"']/g, m => htmlEscapes[m])}${r.errors.includes('Missing empty line after headers') ? '\r\n' : '\r\n\r\n'}${pld}</code></pre>`;
         }
         document.getElementById(`result-${r.suite}-${r.id}`).innerHTML = markup;
       }


### PR DESCRIPTION
Do not show the hard-coded header separator in the HTML UI or CLI if the empty line is missing.